### PR TITLE
Make sure addon runs after ember-cli-postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "after": "ember-cli-uglify"
+    "after": [
+      "ember-cli-uglify",
+      "ember-cli-postcss"
+    ]
   }
 }


### PR DESCRIPTION
When using `ember-cli-postcss` to process the css, like adding autoprefixer and other css optimisations this addon needs to run after so all modifications are present in the included css. This PR fixes that and makes sure `postcss` is running before this addon.